### PR TITLE
fix(#144):Arrumando Ordenação dos pontos de partidas

### DIFF
--- a/src/app/starting-points/page.tsx
+++ b/src/app/starting-points/page.tsx
@@ -31,6 +31,10 @@ const StartPointPage: React.FC = () => {
   const { data: session } = useSession();
   const fetchStartPoints = async (): Promise<StartPoint[]> => {
     const startPoints = await getStartPointsByUser(session?.user.id!);
+    
+    startPoints.sort((a, b) => a.order - b.order)
+    
+
     setListStartPoints(startPoints);
     setFilteredStartPoints(startPoints);
     return startPoints;

--- a/src/app/starting-points/page.tsx
+++ b/src/app/starting-points/page.tsx
@@ -29,31 +29,8 @@ import { UpdateStartPointForm } from '@/components/forms/editStartPoint.form';
 
 const StartPointPage: React.FC = () => {
   const { data: session } = useSession();
-  const fetchStartPoints = async (): Promise<StartPoint[]> => {
-    const startPoints = await getStartPointsByUser(session?.user.id!);
-    
-    startPoints.sort((a, b) => a.order - b.order)
-    
-
-    setListStartPoints(startPoints);
-    setFilteredStartPoints(startPoints);
-    return startPoints;
-  };
-
-  const {
-    data = [],
-    isLoading,
-
-    error,
-  } = useQuery<StartPoint[], Error>({
-    queryKey: ['startpoints', session?.user.id],
-    queryFn: fetchStartPoints,
-  });
-
   const [listStartPoints, setListStartPoints] = useState<StartPoint[]>([]);
-  const [filteredStartPoints, setFilteredStartPoints] = useState<StartPoint[]>(
-    [],
-  );
+  const [filteredStartPoints, setFilteredStartPoints] = useState<StartPoint[]>([]);
   const [searchQuery, setSearchQuery] = useState<string>('');
 
   const [selectedStartPoint, setSelectedStartPoint] =
@@ -63,6 +40,31 @@ const StartPointPage: React.FC = () => {
     useState<boolean>(false);
   const [editionDialogOpen, setEditionDialogOpen] = useState<boolean>(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+
+  const fetchStartPoints = async (): Promise<StartPoint[]> => {
+    let startPoints: StartPoint[] = [];
+    
+    if (session?.user.role === UserRole.ADMIN) {
+      startPoints = await getStartPoints();
+    } else {
+      startPoints = await getStartPointsByUser(session?.user.id!);
+    }
+    
+    startPoints.sort((a, b) => a.order - b.order);
+    
+    setListStartPoints(startPoints);
+    setFilteredStartPoints(startPoints);
+    return startPoints;
+  };
+
+  const {
+    data = [],
+    isLoading,
+    error,
+  } = useQuery<StartPoint[], Error>({
+    queryKey: ['startpoints', session?.user.id],
+    queryFn: fetchStartPoints,
+  });
 
   useEffect(() => {
     if (searchQuery === '') {
@@ -76,7 +78,7 @@ const StartPointPage: React.FC = () => {
       );
       setFilteredStartPoints(filtered);
     }
-  }, [searchQuery, listStartPoints]);
+  }, [searchQuery, listStartPoints, setFilteredStartPoints]);
 
   const handleMenuOpen = (
     event: React.MouseEvent<HTMLButtonElement>,
@@ -135,6 +137,11 @@ const StartPointPage: React.FC = () => {
     );
   }
 
+  const updateStartPoints = (updatedStartPoints: StartPoint[]) => {
+    setListStartPoints(updatedStartPoints);
+    setFilteredStartPoints(updatedStartPoints);
+  };
+
   return (
     <Box
       sx={{
@@ -155,6 +162,7 @@ const StartPointPage: React.FC = () => {
         onMenuClick={handleMenuOpen}
         onMenuClose={handleMenuClose}
         onStartPointAction={handleStartPointAction}
+        onUpdateStartPoints={updateStartPoints}
       />
 
       <ButtonRed onClick={() => setCreateDialogOpen(true)}>

--- a/src/components/home/homePage.tsx
+++ b/src/components/home/homePage.tsx
@@ -40,6 +40,7 @@ const HomePrincipalPage = () => {
         const { fetchPoints } = JourneyService();
         const allPoints = await fetchPoints();
 
+        allPoints.sort((a, b) => a.order - b.order);
         setAllPoints(allPoints);
       };
       loadPoints();

--- a/src/components/tables/startingpoints.table.tsx
+++ b/src/components/tables/startingpoints.table.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import {
   useMaterialReactTable,
   type MRT_ColumnDef,
@@ -7,18 +7,10 @@ import {
 } from 'material-react-table';
 import {
   Box,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
   IconButton,
   Menu,
   MenuItem,
 } from '@mui/material';
-import { useRouter } from 'next/navigation';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { StartPoint } from '@/lib/interfaces/startPoint.interface';
 import { updatePointOrder } from '@/services/studioMaker.service';
@@ -33,6 +25,7 @@ interface StartpointTableProps {
   ) => void;
   onMenuClose: () => void;
   onStartPointAction: (action: string) => void;
+  onUpdateStartPoints: OnUpdateStartPoints;
 }
 
 const StartpointTable: React.FC<StartpointTableProps> = ({
@@ -41,10 +34,9 @@ const StartpointTable: React.FC<StartpointTableProps> = ({
   onMenuClick,
   onMenuClose,
   onStartPointAction,
+  onUpdateStartPoints,
 }) => {
-  const [startPoint_, setStartPoint_] = useState(startPoints);
   const open = Boolean(anchorEl);
-  const router = useRouter();
   const [selectedStartPoint, setSelectedStartPoint] =
     React.useState<StartPoint | null>(null);
 
@@ -103,20 +95,22 @@ const StartpointTable: React.FC<StartpointTableProps> = ({
 
   const table = useMaterialReactTable({
     columns,
-    data: startPoint_,
+    data: startPoints, // Use diretamente `startPoints` aqui
     enableRowOrdering: true,
+    enablePagination: false,
     muiRowDragHandleProps: ({ table }) => ({
       onDragEnd: async () => {
         const { draggingRow, hoveredRow } = table.getState();
         if (hoveredRow && draggingRow) {
-          const newData = [...startPoint_];
+          const newData = [...startPoints];
           newData.splice(
             (hoveredRow as MRT_Row<StartPoint>).index,
             0,
             newData.splice(draggingRow.index, 1)[0],
           );
-          setStartPoint_(newData);
+
           await updateTrailOrder(newData);
+          onUpdateStartPoints(newData);
         }
       },
     }),
@@ -130,10 +124,10 @@ const StartpointTable: React.FC<StartpointTableProps> = ({
     const response = await updatePointOrder(updatedTrails);
 
     if (response.error) {
-      toast.error('Error ao atualizar order da trilha');
+      toast.error('Erro ao atualizar ordem da trilha');
       return;
     }
-    toast.success('Order da trilha atualizada com sucesso');
+    toast.success('Ordem da trilha atualizada com sucesso');
   };
 
   return (

--- a/src/components/tables/startingpoints.table.tsx
+++ b/src/components/tables/startingpoints.table.tsx
@@ -95,7 +95,7 @@ const StartpointTable: React.FC<StartpointTableProps> = ({
 
   const table = useMaterialReactTable({
     columns,
-    data: startPoints, // Use diretamente `startPoints` aqui
+    data: startPoints,
     enableRowOrdering: true,
     enablePagination: false,
     muiRowDragHandleProps: ({ table }) => ({
@@ -131,7 +131,9 @@ const StartpointTable: React.FC<StartpointTableProps> = ({
   };
 
   return (
-    <MRT_TableContainer table={table} />
+    <Box sx={{ width: '100%', maxWidth: 800 }}>
+      <MRT_TableContainer table={table} />
+    </Box>
   );
 };
 

--- a/src/lib/interfaces/startPoint.interface.ts
+++ b/src/lib/interfaces/startPoint.interface.ts
@@ -5,4 +5,5 @@ export interface StartPoint {
   user: string;
   createdAt: string;
   updatedAt: string;
+  order: number;
 }

--- a/src/services/studioMaker.service.ts
+++ b/src/services/studioMaker.service.ts
@@ -325,6 +325,25 @@ export const updateTrailsOrder = async (
   }
 };
 
+
+export const updatePointOrder = async (
+  updatedPoints: StartPoint[],
+): Promise<any> => {
+  try {
+    const response = await studioMakerApi.patch('/points/update-point-order', {
+      points: updatedPoints,
+    });
+    console.log('Points updated:', response.data);
+    return {
+      data: response.data,
+    };
+  } catch (error) {
+    console.error('Failed to update points', error);
+    return { error: error };
+  }
+};
+
+
 export const updateJourneysOrder = async (
   updatedTrails: Journey[],
 ): Promise<any> => {


### PR DESCRIPTION
### História
**Alberto** deseja **criar ponto de partidas** de aprendizado,
Para **organizar as jornadas** dentro dessa plataforma educacional.

### Tasks

 - [x] Criar protótipo de alta fidelidade.
 - [x] Implementar CRUD de livro.
 - [x] Criar a interface para criação de livros, seguindo o protótipo.
 - [x] Implementar a funcionalidade de adicionar e organizar jornadas de um livro.
 - [x] Permitir a visualização e edição dos livros criados.

### Critérios de Aceitação

 - [ ] Deve ser possível acessar uma lista de jornadas relacionados ao ponto de partida.
 - [ ] Deve ser possível ordenar os pontos de partida.
 - [ ] Um ponto de partida possui várias jornadas, e uma jornada está em apenas um ponto de partida.
 - [ ] Somente o usuário com role de admin podem deletar ponto de partidas de todos os usuários.
 - [ ] Os usuários com role de admin e professor poderá criar/editar/deletar ponto de partidas criados por ele mesmo.
 - [ ] Somente o admin deve poder ordenar os pontos de partida.
### 
![Minhas-Jornadas](https://github.com/user-attachments/assets/cbf9cb8c-e2ef-4e0d-bf21-e47ad0a417ff)
